### PR TITLE
Move to styhead and update layer depends

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_qcom-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-distro = "10"
 
 LAYERDEPENDS_qcom-distro = "qcom"
-LAYERSERIES_COMPAT_qcom-distro = "nanbield scarthgap"
+LAYERSERIES_COMPAT_qcom-distro = "styhead"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS        += "qcom-distro"
 BBFILE_PATTERN_qcom-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-distro = "10"
 
-LAYERDEPENDS_qcom-distro = "qcom"
+LAYERDEPENDS_qcom-distro = "core qcom qcom-hwe"
 LAYERSERIES_COMPAT_qcom-distro = "styhead"


### PR DESCRIPTION
Update layer compatibility to styhead and also making the dependency on oe-core , meata-qcom-hwe explicit.