### PR TITLE
qcom-minimal-image: replace debug-tweaks IMAGE_FEATURE

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -2,7 +2,7 @@ SUMMARY = "Minimal image"
 
 LICENSE = "BSD-3-Clause-Clear"
 
-IMAGE_FEATURES += "splash tools-debug debug-tweaks enable-adbd read-only-rootfs"
+IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging enable-adbd read-only-rootfs"
 
 inherit core-image features_check extrausers image-adbd
 


### PR DESCRIPTION
The debug-tweaks IMAGE_FEATURE has been removed so replace it with corresponding suggested features.