### PR TITLE
qcom distro: enable 'efi' DISTRO_FEATURE

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -11,7 +11,7 @@ TARGET_VENDOR = "-qcom"
 # to make the python below work. Local, site and auto.conf will override it.
 TCMODE ?= "default"
 
-DISTRO_FEATURES:append = " pam overlayfs ptest"
+DISTRO_FEATURES:append = " pam overlayfs ptest efi"
 
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"


### PR DESCRIPTION
Enable 'efi' distro feature to gain EFI support in, among other things, systemd. This enable EFI support in bootctl and systemd-boot.

